### PR TITLE
validate bundle version if an expected version is provided in bundleN…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -274,6 +274,16 @@
 				</exclusion>
 			</exclusions>
 		</dependency>
+		<dependency>
+			<groupId>org.osgi</groupId>
+			<artifactId>org.osgi.core</artifactId>
+			<version>6.0.0</version>
+		</dependency>
+        <dependency>
+            <groupId>org.apache.maven.shared</groupId>
+            <artifactId>maven-osgi</artifactId>
+            <version>0.2.0</version>
+        </dependency>
 
 		<!-- test -->
 		<dependency>


### PR DESCRIPTION
…ame parameter.

This gives developers the ability to append expected bundle version numbers to their bundle names being validated. 

```xml
<plugin>
    <groupId>com.citytechinc.maven.plugins</groupId>
    <artifactId>osgi-bundle-status-maven-plugin</artifactId>
    <version>1.4.0-SNAPSHOT</version>
    <executions>
        <execution>
            <id>status-author</id>
            <goals>
                <goal>status</goal>
            </goals>
            <configuration>
                <bundleNames>
                    <!-- bundle name with expected version delimited by semicolon -->
                    <bundleName>${bundle.symbolicName};${project.version}</bundleName> 
                </bundleNames>
                <host>localhost</host>
                <port>4502</port>
                <username>admin</username>
                <password>admin</password>
            </configuration>
        </execution>
    </executions>
</plugin>
```

If this is generally accepted then I will follow up with updated documentation and site changes.